### PR TITLE
refactor: use indexedmap instead of map for storing campaigns

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -1,16 +1,37 @@
-use cw_storage_plus::{Item, Map};
+use cw_storage_plus::{Index, IndexList, IndexedMap, Item, Map, MultiIndex, UniqueIndex};
 
 use crate::msg::Campaign;
 
 /// The number of campaigns created
 pub const CAMPAIGN_COUNT: Item<u64> = Item::new("campaign_count");
 
-//todo use indexedmap here instead so CAMPAIGNS and MERKLE_ROOT becomes one
-/// The list of campaigns. The key is the campaign id, the value is the campaign data.
-pub const CAMPAIGNS: Map<u64, Campaign> = Map::new("campaigns");
+/// Indexed Map of campaigns. The key is the campaign id, the value is the [Campaign].
+pub const CAMPAIGNS: IndexedMap<u64, Campaign, CampaignIndexes> = IndexedMap::new(
+    "campaigns",
+    CampaignIndexes {
+        owner: MultiIndex::new(
+            |_pk, c| c.owner.to_string(),
+            "campaigns",
+            "campaigns__owner",
+        ),
+        merkle_root: UniqueIndex::new(
+            |c: &Campaign| c.merkle_root.clone(),
+            "campaigns__merkle_root",
+        ),
+    },
+);
 
-/// The merkle root for a given campaign. The key is the campaign id, the value is the root hash.
-pub const MERKLE_ROOT: Map<u64, String> = Map::new("merkle_root");
+pub struct CampaignIndexes<'a> {
+    pub owner: MultiIndex<'a, String, Campaign, String>,
+    pub merkle_root: UniqueIndex<'a, String, Campaign, String>,
+}
+
+impl<'a> IndexList<Campaign> for CampaignIndexes<'a> {
+    fn get_indexes(&'_ self) -> Box<dyn Iterator<Item = &'_ dyn Index<Campaign>> + '_> {
+        let v: Vec<&dyn Index<Campaign>> = vec![&self.owner, &self.merkle_root];
+        Box::new(v.into_iter())
+    }
+}
 
 //todo likely to change, bool works fine when you have a single reward token with lumpsum distribution only
 pub const CLAIMS: Map<(String, u64), bool> = Map::new("claims");


### PR DESCRIPTION
This PR uses an indexedmap instead of a map for storing campaigns. This allows to merge the campaigns and merkle_root maps and makes it easier to do queries.