### PR TITLE
chore: add macro for validating contract before migrating

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,6 @@ cw-utils = { version = "2.0.0" }
 hex = "0.4.3"
 sha2 = { version = "0.10.8", default-features = false }
 cw-migrate-error-derive = { version = "0.1.0" }
-rand = "0.8.5"
 
 [dev-dependencies]
 cw-multi-test = {  version = "2.1.0", features = ["cosmwasm_1_4"]  }

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1,7 +1,6 @@
-use cosmwasm_std::{ensure, entry_point, to_json_binary, StdError};
+use cosmwasm_std::{entry_point, to_json_binary};
 use cosmwasm_std::{Binary, Deps, DepsMut, Env, MessageInfo, Response};
-use cw2::{get_contract_version, set_contract_version, CONTRACT};
-use semver::Version;
+use cw2::set_contract_version;
 
 use crate::error::ContractError;
 use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -273,16 +273,17 @@ pub fn aggregate_claims(
 #[macro_export]
 macro_rules! validate_contract {
     ($deps:expr, $contract_name:expr, $contract_version:expr) => {{
-        let stored_contract_name = CONTRACT.load($deps.storage)?.contract;
-        ensure!(
+        let stored_contract_name = cw2::CONTRACT.load($deps.storage)?.contract;
+        cosmwasm_std::ensure!(
             stored_contract_name == $contract_name,
-            StdError::generic_err("Contract name mismatch")
+            cosmwasm_std::StdError::generic_err("Contract name mismatch")
         );
 
-        let version: Version = $contract_version.parse()?;
-        let storage_version: Version = get_contract_version($deps.storage)?.version.parse()?;
+        let version: semver::Version = $contract_version.parse()?;
+        let storage_version: semver::Version =
+            cw2::get_contract_version($deps.storage)?.version.parse()?;
 
-        ensure!(
+        cosmwasm_std::ensure!(
             storage_version < version,
             ContractError::MigrateInvalidVersion {
                 current_version: storage_version,


### PR DESCRIPTION
This PR adds a macro (to be moved to mantra-std in the future), that validates the contract before migration. This macro makes sure the version and contract name are accurate. 