### PR TITLE
chore: prevent campaign topup if campaign has been closed

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -74,6 +74,13 @@ fn topup_campaign(deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response
         }
     );
 
+    ensure!(
+        campaign.closed.is_none(),
+        ContractError::CampaignError {
+            reason: "campaign has been closed".to_string()
+        }
+    );
+
     let topup = cw_utils::must_pay(&info, &campaign.reward_asset.denom)?;
     campaign.reward_asset.amount = campaign.reward_asset.amount.checked_add(topup)?;
 
@@ -100,6 +107,13 @@ fn close_campaign(deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response
     ensure!(
         campaign.owner == info.sender || cw_ownable::is_owner(deps.storage, &info.sender)?,
         ContractError::Unauthorized
+    );
+
+    ensure!(
+        campaign.closed.is_none(),
+        ContractError::CampaignError {
+            reason: "campaign has already been closed".to_string()
+        }
     );
 
     let refund = campaign

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2488,10 +2488,39 @@ fn close_campaigns() {
                 result.unwrap();
             },
         )
+        .manage_campaign(
+            dan, // dan tries closing the campaign again
+            CampaignAction::CloseCampaign {},
+            &[],
+            |result: Result<AppResponse, anyhow::Error>| {
+                let err = result.unwrap_err().downcast::<ContractError>().unwrap();
+                match err {
+                    ContractError::CampaignError { reason } => {
+                        assert_eq!(reason, "campaign has already been closed");
+                    }
+                    _ => panic!("Wrong error type, should return ContractError::CampaignError"),
+                }
+            },
+        )
         .query_campaign(|result| {
             let campaign = result.unwrap();
             assert!(campaign.closed.is_some());
-        });
+        })
+        // try top up, should fail
+        .manage_campaign(
+            dan,
+            CampaignAction::TopUpCampaign {},
+            &coins(100_000, "uom"),
+            |result: Result<AppResponse, anyhow::Error>| {
+                let err = result.unwrap_err().downcast::<ContractError>().unwrap();
+                match err {
+                    ContractError::CampaignError { reason } => {
+                        assert_eq!(reason, "campaign has been closed");
+                    }
+                    _ => panic!("Wrong error type, should return ContractError::CampaignError"),
+                }
+            },
+        );
 
     // let's create a new campaign
     suite.instantiate_airdrop_manager(None).manage_campaign(


### PR DESCRIPTION
This PR prevents a campaign being topped up if it's closed. Also fails to close an already closed campaign.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced campaign management with additional checks to prevent actions on closed campaigns.
	- Improved error handling for campaign management actions.

- **Bug Fixes**
	- Added tests to ensure appropriate errors are raised for invalid campaign actions.

- **Tests**
	- Expanded test coverage for campaign management, ownership scenarios, and reward claims.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->