### PR TITLE
chore: add missing event on instantiation

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -19,13 +19,13 @@ pub fn instantiate(
 ) -> Result<Response, ContractError> {
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 
-    cw_ownable::initialize_owner(
-        deps.storage,
-        deps.api,
-        Some(&msg.owner.unwrap_or(info.sender.into_string())),
-    )?;
+    let owner = msg.owner.unwrap_or(info.sender.into_string());
+    cw_ownable::initialize_owner(deps.storage, deps.api, Some(&owner))?;
 
-    Ok(Response::default())
+    Ok(Response::default().add_attributes(vec![
+        ("action", "instantiate".to_string()),
+        ("owner", owner),
+    ]))
 }
 
 #[entry_point]


### PR DESCRIPTION
Add missing attributes on the response of the instantiate message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the contract instantiation response to include additional attributes: `"action"` and `"owner"`.
- **Refactor**
	- Improved readability by separating the owner determination logic from the function call during contract instantiation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->