### PR TITLE
ci: add validation for single claim entry in csv file

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ of the campaign upon creation.
 - The owner of the campaign can top up the campaign with more tokens at any point before the campaign ends.
 - The owner of the campaign or the owner of the contract can close the campaign at any point before the campaign ends. 
 When a campaign is ended, the owner of the campaign will receive the remaining, unclaimed tokens in the campaign.
+- Only a single claim entry per address is allowed.
 
 ## When can it be used?
 

--- a/scripts/merkle_root.js
+++ b/scripts/merkle_root.js
@@ -5,7 +5,16 @@ const {MerkleTree} = require('merkletreejs');
 
 class AirdropCampaign {
     constructor(items) {
-        const leaves = items.map(i => sha256(i.contract_addr + i.address + i.amount));
+        const addressSet = new Set();
+        const leaves = items.map(i => {
+            const leaf = sha256(i.contract_addr + i.address + i.amount);
+            if (addressSet.has(i.address)) {
+                console.error(`Error: Duplicate entry for address ${i.address}`);
+                process.exit(1);
+            }
+            addressSet.add(i.address);
+            return leaf;
+        });
         this.tree = new MerkleTree(leaves, sha256, {sort: true});
     }
 


### PR DESCRIPTION
Fixes #26 by adding a validation on the `merkle_root.js` script to ensure each address has a unique entry in the csv file. Also added a warning in the [docs](https://docs.mantrachain.io/mantra-smart-contracts/airdrop_manager#generating-airdrop-data).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated documentation to clarify that only one claim entry per address is allowed in the Airdrop Manager.
	- Enhanced validation in the AirdropCampaign to prevent duplicate addresses during claim submissions.

- **Bug Fixes**
	- Improved error handling to ensure unique addresses are processed, preventing issues with duplicate entries in the Merkle tree.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->