### PR TITLE
chore: make it possible to receive rounding errors when there are no other new claims

### DIFF
--- a/tests/hashes.rs
+++ b/tests/hashes.rs
@@ -5,7 +5,6 @@ pub const ALICE_PROOFS: &[&str] = &[
     "507a831ce92ef25b84974994ea57bda8815759c83e2a111e5fe2e2a2f87c6e28",
     "efd074c475dd84fcdae3e32bd38b0476725cf775abe198d1456a0d79cb34bcbc",
 ];
-
 pub const BOB_PROOFS: &[&str] = &[
     "1bc5a0524fc64283f032b343849694d597ad97ce610b56fa64cbcad9efa9032a",
     "13ae04bac537b5d064cb7a109ad5f503d43b87aca0ed25411efe0d5a011f22bc",
@@ -29,5 +28,13 @@ pub const BROKEN_PROOFS: &[&str] = &[
     "fc4c2d93999e295f62de5325be0be1d1d1183083abe332559cde91f14d830f70",
     "efd074c475dd84fcdae3e32bd38b0476725cf775abe198d1456a0d79cb34bcbc",
     "bf74e593d82df998cc8b529aa304b53e73fa624e5ca18723891b6bcbc7696fab",
+    "efd074c475dd84fcdae3e32bd38b0476725cf775abe198d1456a0d79cb34bcbc",
+];
+
+pub const MERKLE_ROOT_X: &str = "99f14ebb813bd79247912b39584f98af740631bd91d5fd3fec533a346c462c81";
+
+pub const ALICE_PROOFS_X: &[&str] = &[
+    "1bc5a0524fc64283f032b343849694d597ad97ce610b56fa64cbcad9efa9032a",
+    "d3fafecc7b46d0b0b0ac9a0689e8c63f07868dc48af91bcdfee98e0225e76212",
     "efd074c475dd84fcdae3e32bd38b0476725cf775abe198d1456a0d79cb34bcbc",
 ];


### PR DESCRIPTION
Fixes #28 by adding a new claim for the distribution slot instead of erroring when no new claims are made.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced claim handling logic to prevent runtime errors related to missing claims.
	- Introduced a new test case to verify the ability to claim small token amounts without creating new claims.

- **Bug Fixes**
	- Improved robustness of claims by initializing new claims when necessary.

- **Tests**
	- Added new constants for testing: `MERKLE_ROOT_X` and `ALICE_PROOFS_X`.
	- Expanded test suite with additional test cases for edge scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->