### PR TITLE
chore: ensure the distribution end time is lower or equal than campaign endtime

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -59,6 +59,12 @@ pub enum ContractError {
     #[error("Invalid start distribution time, start time: {start_time}, current time: {current_time}. The start time needs to be in the future.")]
     InvalidStartDistributionTime { start_time: u64, current_time: u64 },
 
+    #[error("Invalid end distribution time, end time: {end_time}, campaign_end_time: {campaign_end_time}. The distribution end time needs to be less or equal to the campaign's end time.")]
+    InvalidEndDistributionTime {
+        end_time: u64,
+        campaign_end_time: u64,
+    },
+
     #[error("There's nothing to claim for the given address")]
     NothingToClaim,
 

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -338,6 +338,14 @@ impl CampaignParams {
                     end_time: *end_time,
                 }
             );
+
+            ensure!(
+                *end_time <= self.end_time,
+                ContractError::InvalidEndDistributionTime {
+                    end_time: *end_time,
+                    campaign_end_time: self.end_time,
+                }
+            );
         }
 
         ensure!(


### PR DESCRIPTION
Fixes #30 by ensuring no distribution type can end after the campaign.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new error variant for handling invalid distribution end times in campaigns.
	- Enhanced validation to ensure distribution end times do not exceed campaign end times.

- **Bug Fixes**
	- Added validation checks to prevent campaigns from being created with invalid distribution end times.

- **Tests**
	- Added a new test case to verify that campaigns cannot be created with an end time earlier than the start time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->