### PR TITLE
chore: boost max limit for query pagination

### DIFF
--- a/src/msg.rs
+++ b/src/msg.rs
@@ -54,7 +54,7 @@ pub enum QueryMsg {
         /// The address to start querying from. Used for paginating results.
         start_from: Option<String>,
         /// The maximum number of items to return. If not set, the default value is used. Used for paginating results.
-        limit: Option<u8>,
+        limit: Option<u16>,
     },
 }
 

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -80,14 +80,14 @@ pub(crate) fn query_rewards(
 }
 
 // settings for pagination
-pub(crate) const MAX_LIMIT: u8 = 100;
-const DEFAULT_LIMIT: u8 = 20;
+pub(crate) const MAX_LIMIT: u16 = 5_000;
+const DEFAULT_LIMIT: u16 = 100;
 
 pub(crate) fn query_claimed(
     deps: Deps,
     address: Option<String>,
     start_from: Option<String>,
-    limit: Option<u8>,
+    limit: Option<u16>,
 ) -> Result<ClaimedResponse, ContractError> {
     let mut claimed = vec![];
 


### PR DESCRIPTION
This PR boosts the amount of claims that can be query at once with the `Claimed` query. Benchmarked to to perform well querying 5000 values at once. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced pagination capabilities with increased limits for claimed queries.
	- Maximum limit for pagination increased to 5,000, and default limit set to 100.

- **Bug Fixes**
	- Adjusted the limit type in query functions to accommodate larger values, ensuring better handling of pagination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->