### PR TITLE
chore: use validate_raw_address

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -11,7 +11,7 @@ use crate::state::{
 };
 
 /// Maximum number of allocations that can be added in a single batch
-const MAX_ALLOCATION_BATCH_SIZE: usize = 3000;
+pub const MAX_ALLOCATION_BATCH_SIZE: usize = 3000;
 
 /// Manages a campaign
 pub(crate) fn manage_campaign(

--- a/src/error.rs
+++ b/src/error.rs
@@ -72,6 +72,9 @@ pub enum ContractError {
 
     #[error("Invalid input: {reason}")]
     InvalidInput { reason: String },
+
+    #[error("Batch size limit exceeded: {actual}, maximum allowed: {max}")]
+    BatchSizeLimitExceeded { actual: usize, max: usize },
 }
 
 impl From<semver::Error> for ContractError {

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -128,6 +128,7 @@ pub(crate) fn query_claimed(
     }
 
     if let Some(address) = address {
+        // For an address to have claimed, it must have been a valid cosmos address
         let address = deps.api.addr_validate(&address)?.to_string();
         let claims = CLAIMS.may_load(deps.storage, address.clone())?;
 
@@ -173,9 +174,6 @@ pub(crate) fn query_claimed(
     Ok(ClaimedResponse { claimed })
 }
 
-const MAX_ALLOCATIONS: u16 = 5_000;
-const DEFAULT_ALLOCATIONS_LIMIT: u16 = 100;
-
 /// Returns the allocation for an address.
 ///
 /// # Arguments
@@ -200,9 +198,7 @@ pub fn query_allocation(
             vec![]
         }
     } else {
-        let limit = limit
-            .unwrap_or(DEFAULT_ALLOCATIONS_LIMIT)
-            .min(MAX_ALLOCATIONS) as usize;
+        let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
         let start = cw_utils::calc_range_start_string(start_after).map(Bound::ExclusiveRaw);
 
         ALLOCATIONS

--- a/src/state.rs
+++ b/src/state.rs
@@ -4,6 +4,7 @@ use cosmwasm_std::{Deps, Uint128};
 use cw_storage_plus::{Item, Map};
 
 use crate::error::ContractError;
+use crate::helpers;
 use crate::msg::Campaign;
 
 /// The campaign item that stores the current active campaign
@@ -39,7 +40,7 @@ pub fn get_claims_for_address(
     deps: Deps,
     address: String,
 ) -> Result<HashMap<DistributionSlot, Claim>, ContractError> {
-    let claimed = CLAIMS.may_load(deps.storage, address.to_lowercase())?;
+    let claimed = CLAIMS.may_load(deps.storage, helpers::validate_raw_address(deps, &address)?)?;
     Ok(claimed.unwrap_or_default())
 }
 
@@ -73,7 +74,10 @@ pub fn get_total_claims_amount_for_address(
 /// # Returns
 /// * `Result<Option<Uint128>, ContractError>` - The allocation amount if it exists
 pub fn get_allocation(deps: Deps, address: &str) -> Result<Option<Uint128>, ContractError> {
-    Ok(ALLOCATIONS.may_load(deps.storage, address.to_lowercase().as_str())?)
+    Ok(ALLOCATIONS.may_load(
+        deps.storage,
+        helpers::validate_raw_address(deps, address)?.as_str(),
+    )?)
 }
 
 /// Returns whether an address is blacklisted
@@ -86,6 +90,9 @@ pub fn get_allocation(deps: Deps, address: &str) -> Result<Option<Uint128>, Cont
 /// * `Result<bool, ContractError>` - Whether the address is blacklisted
 pub fn is_blacklisted(deps: Deps, address: &str) -> Result<bool, ContractError> {
     Ok(BLACKLIST
-        .may_load(deps.storage, address.to_lowercase().as_str())?
+        .may_load(
+            deps.storage,
+            helpers::validate_raw_address(deps, address)?.as_str(),
+        )?
         .unwrap_or(false))
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,6 +1,6 @@
-use std::result;
 use std::str::FromStr;
 
+use claimdrop_contract::commands::MAX_ALLOCATION_BATCH_SIZE;
 use claimdrop_contract::helpers::MAX_PLACEHOLDER_ADDRESS_LEN;
 use cosmwasm_std::{coin, coins, Addr, Decimal, StdError, StdResult, Uint128};
 use cw_multi_test::AppResponse;
@@ -3504,7 +3504,6 @@ fn cant_add_allocations_with_invalid_placeholders() {
         coin(1_000_000_000, "uusdc"),
     ]);
     let alice = &suite.senders[0].clone();
-    let bob = &suite.senders[1].clone();
 
     let aave = "0x24a42fD28C976A61Df5D00D0599C34c4f90748c8";
     let valid_mantra_address = "mantra1w8e2wyzhrg3y5ghe9yg0xn0u7548e627zs7xahfvn5l63ry2x8zsqru7xd";
@@ -3616,7 +3615,7 @@ fn test_allocation_batch_size_limit() {
 
     // Create a batch that exceeds the limit
     let mut large_batch = Vec::new();
-    for i in 0..3001 {
+    for i in 0..=MAX_ALLOCATION_BATCH_SIZE {
         large_batch.push((format!("address{}", i), Uint128::new(100)));
     }
 
@@ -3627,8 +3626,8 @@ fn test_allocation_batch_size_limit() {
             let err = result.unwrap_err().downcast::<ContractError>().unwrap();
             match err {
                 ContractError::BatchSizeLimitExceeded { actual, max } => {
-                    assert_eq!(actual, 3001);
-                    assert_eq!(max, 3000);
+                    assert_eq!(actual, MAX_ALLOCATION_BATCH_SIZE + 1);
+                    assert_eq!(max, MAX_ALLOCATION_BATCH_SIZE);
                 }
                 _ => {
                     panic!("Wrong error type, should return ContractError::BatchSizeLimitExceeded")
@@ -3639,7 +3638,7 @@ fn test_allocation_batch_size_limit() {
 
     // Test that exactly 3000 allocations work fine
     let mut max_batch = Vec::new();
-    for i in 0..3000 {
+    for i in 0..MAX_ALLOCATION_BATCH_SIZE {
         max_batch.push((format!("addr{}", i), Uint128::new(100)));
     }
 


### PR DESCRIPTION
This PR uses `validate_raw_address` consistently, as well as adds a maximum limit to the batch upload operation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a maximum batch size limit of 3000 for adding allocations. Users will receive an error if they attempt to add more than 3000 allocations at once.
- **Bug Fixes**
  - Improved address validation for address replacement, removal, and blacklisting to ensure stricter and more consistent checks.
- **Tests**
  - Added an integration test to verify enforcement of the allocation batch size limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->