### PR TITLE
feat: only owner can claim on behalf of others

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -768,9 +768,9 @@ checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "mantra-claimdrop-std"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b198a4f9f67261296179f041c18780d0c1043e2fd982d7b1778c007aa1fb96"
+checksum = "ea4192a68c7a5236cff7bc333ac740c5a49bd881f931d0e04a9b4fc14b833966"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ semver = { version = "1.0.23" }
 cw-ownable = { version = "2.1.0" }
 cw-utils = { version = "2.0.0" }
 cw-migrate-error-derive = { version = "0.1.0" }
-mantra-claimdrop-std = { version = "1.1.0" }
+mantra-claimdrop-std = { version = "1.1.1" }
 
 [dev-dependencies]
 cw-multi-test = {  version = "2.1.0", features = ["cosmwasm_1_4"]  }


### PR DESCRIPTION
This PR makes it possible for only the owner to claim on behalf of others.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved claim process by adding an authorization check to ensure only the contract owner or the intended receiver can claim rewards.

* **Tests**
  * Added new tests to verify claim authorization, ensuring unauthorized users cannot claim on behalf of others.
  * Updated existing tests for clearer error handling and accurate claim scenarios.

* **Chores**
  * Updated a dependency to the latest version for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->