### PR TITLE
fix: make raw address validation more flexible

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -284,16 +284,12 @@ pub fn validate_address_placeholder(placeholder: &str) -> Result<String, Contrac
         }
     );
 
-    // only alphanumeric characters and dots allowed, i.e. for 0x addresses or ENS domains
-    if !address
-        .chars()
-        .all(|c| c.is_ascii_alphanumeric() || c == '.')
-    {
+    // Very permissive validation to support various placeholder types:
+    // ENS domains (with emoji, international characters), email addresses, social handles, etc.
+    // Only block control characters which could cause parsing/display issues
+    if address.chars().any(|c| c.is_control()) {
         return Err(ContractError::InvalidInput {
-            reason: format!(
-                "placeholder address '{}' contains invalid characters",
-                placeholder
-            ),
+            reason: format!("placeholder address '{placeholder}' contains control characters"),
         });
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3826,7 +3826,7 @@ fn cant_add_allocations_with_invalid_placeholders() {
                     assert_eq!(
                         reason,
                         format!(
-                            "placeholder address '{}' contains invalid characters",
+                            "placeholder address '{}' contains control characters",
                             invalid_chars
                         )
                         .to_string()

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -23,7 +23,7 @@ fn invalid_bech32_but_valid_placeholder() {
 #[test]
 fn invalid_bech32_and_invalid_placeholder() {
     let deps = mock_dependencies();
-    let address_raw = "invalid#address";
+    let address_raw = "invalid\x01address"; // control character (should fail)
     let result = validate_raw_address(deps.as_ref(), address_raw);
     assert!(matches!(result, Err(ContractError::InvalidInput { .. })));
 }
@@ -54,9 +54,198 @@ fn placeholder_too_long() {
 }
 
 #[test]
-fn placeholder_with_invalid_chars() {
+fn placeholder_with_control_chars() {
     let deps = mock_dependencies();
-    let address_raw = "invalid_address!";
+    let address_raw = "invalid\x00address"; // null character (control char)
     let result = validate_raw_address(deps.as_ref(), address_raw);
     assert!(matches!(result, Err(ContractError::InvalidInput { .. })));
+}
+
+// ENS Domain Tests
+#[test]
+fn ens_basic_domain() {
+    let deps = mock_dependencies();
+    let address_raw = "example.eth";
+    let result = validate_raw_address(deps.as_ref(), address_raw);
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), "example.eth");
+}
+
+#[test]
+fn ens_subdomain() {
+    let deps = mock_dependencies();
+    let address_raw = "sub.domain.eth";
+    let result = validate_raw_address(deps.as_ref(), address_raw);
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), "sub.domain.eth");
+}
+
+#[test]
+fn ens_emoji_single() {
+    let deps = mock_dependencies();
+    let address_raw = "🌮.eth";
+    let result = validate_raw_address(deps.as_ref(), address_raw);
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), "🌮.eth");
+}
+
+#[test]
+fn ens_emoji_multiple() {
+    let deps = mock_dependencies();
+    let address_raw = "👁👄👁.eth";
+    let result = validate_raw_address(deps.as_ref(), address_raw);
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), "👁👄👁.eth");
+}
+
+#[test]
+fn ens_emoji_sequence() {
+    let deps = mock_dependencies();
+    let address_raw = "🌑🌒🌓🌔🌕.eth";
+    let result = validate_raw_address(deps.as_ref(), address_raw);
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), "🌑🌒🌓🌔🌕.eth");
+}
+
+#[test]
+fn ens_international_latin_accents() {
+    let deps = mock_dependencies();
+    let address_raw = "café.eth";
+    let result = validate_raw_address(deps.as_ref(), address_raw);
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), "café.eth");
+}
+
+#[test]
+fn ens_cyrillic() {
+    let deps = mock_dependencies();
+    let address_raw = "привет.eth";
+    let result = validate_raw_address(deps.as_ref(), address_raw);
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), "привет.eth");
+}
+
+#[test]
+fn ens_chinese() {
+    let deps = mock_dependencies();
+    let address_raw = "中文.eth";
+    let result = validate_raw_address(deps.as_ref(), address_raw);
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), "中文.eth");
+}
+
+#[test]
+fn ens_japanese() {
+    let deps = mock_dependencies();
+    let address_raw = "日本語.eth";
+    let result = validate_raw_address(deps.as_ref(), address_raw);
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), "日本語.eth");
+}
+
+#[test]
+fn ens_korean() {
+    let deps = mock_dependencies();
+    let address_raw = "한국어.eth";
+    let result = validate_raw_address(deps.as_ref(), address_raw);
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), "한국어.eth");
+}
+
+#[test]
+fn ens_bitcoin_symbol() {
+    let deps = mock_dependencies();
+    let address_raw = "₿itcoin.eth";
+    let result = validate_raw_address(deps.as_ref(), address_raw);
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), "₿itcoin.eth");
+}
+
+#[test]
+fn ens_with_hyphens() {
+    let deps = mock_dependencies();
+    let address_raw = "test-domain.eth";
+    let result = validate_raw_address(deps.as_ref(), address_raw);
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), "test-domain.eth");
+}
+
+#[test]
+fn ens_with_underscores() {
+    let deps = mock_dependencies();
+    let address_raw = "test_domain.eth";
+    let result = validate_raw_address(deps.as_ref(), address_raw);
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), "test_domain.eth");
+}
+
+// Other Placeholder Types
+#[test]
+fn email_like_placeholder() {
+    let deps = mock_dependencies();
+    let address_raw = "user@example.com";
+    let result = validate_raw_address(deps.as_ref(), address_raw);
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), "user@example.com");
+}
+
+#[test]
+fn social_handle_at() {
+    let deps = mock_dependencies();
+    let address_raw = "@username";
+    let result = validate_raw_address(deps.as_ref(), address_raw);
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), "@username");
+}
+
+#[test]
+fn social_handle_hash() {
+    let deps = mock_dependencies();
+    let address_raw = "#hashtag";
+    let result = validate_raw_address(deps.as_ref(), address_raw);
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), "#hashtag");
+}
+
+#[test]
+fn mixed_symbols_and_numbers() {
+    let deps = mock_dependencies();
+    let address_raw = "user-123_test!@#$%";
+    let result = validate_raw_address(deps.as_ref(), address_raw);
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), "user-123_test!@#$%");
+}
+
+#[test]
+fn special_unicode_symbols() {
+    let deps = mock_dependencies();
+    let address_raw = "★☆♠♥♦♣♪♫";
+    let result = validate_raw_address(deps.as_ref(), address_raw);
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), "★☆♠♥♦♣♪♫");
+}
+
+// Ethereum Address Tests
+#[test]
+fn ethereum_address_lowercase() {
+    let deps = mock_dependencies();
+    let address_raw = "0x742d35cc6361c4c93f09bb9eca5e90de2c0a5b8f";
+    let result = validate_raw_address(deps.as_ref(), address_raw);
+    assert!(result.is_ok());
+    assert_eq!(
+        result.unwrap(),
+        "0x742d35cc6361c4c93f09bb9eca5e90de2c0a5b8f"
+    );
+}
+
+#[test]
+fn ethereum_address_mixed_case() {
+    let deps = mock_dependencies();
+    let address_raw = "0x742d35Cc6361c4c93f09bB9eca5e90de2c0a5B8F";
+    let result = validate_raw_address(deps.as_ref(), address_raw);
+    assert!(result.is_ok());
+    assert_eq!(
+        result.unwrap(),
+        "0x742d35cc6361c4c93f09bb9eca5e90de2c0a5b8f"
+    );
 }


### PR DESCRIPTION
Fixes #68 by making the raw address validation more permissive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Expanded placeholder address validation to accept international characters and emoji (e.g., ENS-like domains, emails, social handles), rejecting only control characters.
  - Preserves input for non-address placeholders; Ethereum addresses are normalized to lowercase.
  - Updated error message to clearly indicate when control characters are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->