### PR TITLE
Problem(ClaimDrop): Blacklisted users can still see pending amount

### DIFF
--- a/evm/contracts/Claimdrop.sol
+++ b/evm/contracts/Claimdrop.sol
@@ -617,10 +617,10 @@ contract Claimdrop is Ownable2Step, ReentrancyGuard, Pausable {
         claimed = _getTotalClaimedForAddress(addr);
 
         // Allow pending calculation even after closure (vesting frozen at closedAt)
-        if (campaign.exists && block.timestamp >= campaign.startTime) {
-            (pending,) = _computeClaimableAmount(addr, total);
-        } else if (isBlacklisted(addr)) {
+        if (isBlacklisted(addr)) {
             pending = 0;
+        } else if (campaign.exists && block.timestamp >= campaign.startTime) {
+            (pending,) = _computeClaimableAmount(addr, total);
         } else {
             pending = 0;
         }

--- a/evm/test/Claimdrop.t.sol
+++ b/evm/test/Claimdrop.t.sol
@@ -3274,7 +3274,7 @@ contract ClaimdropTest is Test {
         assertEq(total, 1000 ether, "Total should be the allocation amount");
     }
 
-    function test_ShouldReturnVestedAmountForBlacklistedUserAfterCampaignStart() public {
+    function test_ShouldReturnZeroAmountForBlacklistedUserAfterCampaignStart() public {
         createTestCampaign(); // 30% lump sum, 70% vesting
         addTestAllocations(1, 1000 ether); // User1 gets 300 lump, 700 vesting
 
@@ -3284,14 +3284,14 @@ contract ClaimdropTest is Test {
         // Warp to start. `getRewards` should now enter the first `if` branch.
         warpToStart();
         (, uint256 pending,) = claimdrop.getRewards(user1);
-        assertEq(pending, 300 ether, "Pending should show vested amount for blacklisted user after start");
+        assertEq(pending, 0 ether, "Pending should show vested amount for blacklisted user after start");
 
         // At 50% through vesting period
         uint256 halfTime = startTime + (endTime - startTime) / 2;
         vm.warp(halfTime);
         (, uint256 pending50,) = claimdrop.getRewards(user1);
         // 300 from lump sum + 350 from vesting (50% of 700)
-        assertApproxEqAbs(pending50, 650 ether, 1 ether, "Pending should include vested amount for blacklisted user");
+        assertApproxEqAbs(pending50, 0 ether, 1 ether, "Pending should include vested amount for blacklisted user");
 
         // And check that claiming is reverted, because user is blacklisted.
         vm.prank(user1);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Blacklisted addresses now correctly receive zero pending rewards, regardless of campaign status or vesting progress.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->